### PR TITLE
feat(definitions-parser): Add pdfjs-dist to allowed package deps

### DIFF
--- a/packages/definitions-parser/allowedPackageJsonDependencies.txt
+++ b/packages/definitions-parser/allowedPackageJsonDependencies.txt
@@ -445,6 +445,7 @@ opentracing
 parchment
 parse5
 path-to-regexp
+pdfjs-dist
 pg-protocol
 pg-types
 pkcs11js


### PR DESCRIPTION
Adds pdfjs-dist to allowedPackageJsonDependencies.txt.

Required for DefinitelyTyped/DefinitelyTyped#56226.
